### PR TITLE
Add public AI predictions page with map view and publish/retract flow for offline predictions

### DIFF
--- a/frontend/src/app/routes/published-predictions.tsx
+++ b/frontend/src/app/routes/published-predictions.tsx
@@ -52,7 +52,7 @@ export const PublishedPredictionsPage = () => {
     closeDialog: closePredictionResultDialog,
   } = useDialog();
 
-  const [isDetailDialogOpen, setIsDetailDialogOpen] = useState(false);
+  const [isDetailDialogOpen, setIsDetailDialogOpen] = useState<boolean>(false);
   const mapViewElementId = "published-predictions-map-view";
   const { scrollToElement } = useScrollToElement(mapViewElementId);
   const { scrollToTop } = useScrollToTop();

--- a/frontend/src/features/published-predictions/components/published-predictions-filters.tsx
+++ b/frontend/src/features/published-predictions/components/published-predictions-filters.tsx
@@ -85,32 +85,64 @@ export const PublishedPredictionsFilters = ({
       </div>
 
       {/* Count, sort, pagination, layout row */}
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
         <p className="text-body-3 font-semibold text-nowrap">
           {totalCount} Prediction{totalCount !== 1 ? "s" : ""}
         </p>
 
-        <div className="flex items-center gap-x-4 flex-wrap">
-          {/* Sort */}
-          <DropDown
-            menuItems={orderingMenuItems}
-            handleMenuSelection={(selectedLabel: string) => {
-              const opt = ORDERING_OPTIONS.find(
-                (o) => o.label === selectedLabel,
-              );
-              if (opt) onOrderingChange(opt.value);
-            }}
-            withCheckbox
-            defaultSelectedItem={selectedOrderingLabel}
-            triggerComponent={
-              <p className="text-xs md:text-sm text-dark text-nowrap cursor-pointer">
-                Sort by
-              </p>
-            }
-          />
+        <div className="w-full sm:w-auto flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-x-4">
+          <div className="flex items-center justify-between w-full sm:w-auto sm:justify-start sm:gap-x-4">
+            {/* Sort */}
+            <DropDown
+              menuItems={orderingMenuItems}
+              handleMenuSelection={(selectedLabel: string) => {
+                const opt = ORDERING_OPTIONS.find(
+                  (o) => o.label === selectedLabel,
+                );
+                if (opt) onOrderingChange(opt.value);
+              }}
+              withCheckbox
+              defaultSelectedItem={selectedOrderingLabel}
+              triggerComponent={
+                <p className="text-xs md:text-sm text-dark text-nowrap cursor-pointer">
+                  Sort by
+                </p>
+              }
+            />
+
+            <div className="flex items-center gap-x-3 shrink-0">
+              <ShowMapToggle
+                query={mapToggleQuery}
+                updateQuery={(params) => {
+                  onMapViewChange(Boolean(params[SEARCH_PARAMS.mapIsActive]));
+                }}
+              />
+
+              {/* Layout toggle */}
+              <ToolTip
+                content={`Show as ${isGridView ? LayoutView.LIST : LayoutView.GRID}`}
+              >
+                <button
+                  className="border border-gray-border p-2 items-center flex justify-center text-dark cursor-pointer"
+                  disabled={mapViewIsActive}
+                  onClick={() =>
+                    onLayoutChange(
+                      isGridView ? LayoutView.LIST : LayoutView.GRID,
+                    )
+                  }
+                >
+                  {isGridView ? (
+                    <ListIcon className="icon" />
+                  ) : (
+                    <CategoryIcon className="icon" />
+                  )}
+                </button>
+              </ToolTip>
+            </div>
+          </div>
 
           {/* Pagination */}
-          <div className="flex items-center gap-x-2">
+          <div className="flex items-center md:justify-end gap-x-2">
             <p className="text-body-4 text-nowrap">
               <span className="font-semibold">
                 {totalCount > 0 ? offset + 1 : 0}-{endIndex}
@@ -138,30 +170,6 @@ export const PublishedPredictionsFilters = ({
               />
             </button>
           </div>
-          <ShowMapToggle
-            query={mapToggleQuery}
-            updateQuery={(params) => {
-              onMapViewChange(Boolean(params[SEARCH_PARAMS.mapIsActive]));
-            }}
-          />
-          {/* Layout toggle */}
-          <ToolTip
-            content={`Show as ${isGridView ? LayoutView.LIST : LayoutView.GRID}`}
-          >
-            <button
-              className="border border-gray-border p-2 items-center flex justify-center text-dark cursor-pointer"
-              disabled={mapViewIsActive}
-              onClick={() =>
-                onLayoutChange(isGridView ? LayoutView.LIST : LayoutView.GRID)
-              }
-            >
-              {isGridView ? (
-                <ListIcon className="icon" />
-              ) : (
-                <CategoryIcon className="icon" />
-              )}
-            </button>
-          </ToolTip>
         </div>
       </div>
     </div>

--- a/frontend/src/features/published-predictions/components/published-predictions-table.tsx
+++ b/frontend/src/features/published-predictions/components/published-predictions-table.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
 import { ToolTip } from "@/components/ui/tooltip";
-import { NoTrainingAreaIcon, MapIcon, InfoIcon } from "@/components/ui/icons";
+import { NoTrainingAreaIcon,InfoIcon } from "@/components/ui/icons";
 import { ColumnDef, SortingState } from "@tanstack/react-table";
 import { SortableHeader } from "@/features/models/components/table-header";
 import { TableSkeleton } from "@/features/models/components/skeletons";
@@ -40,12 +40,12 @@ const columnDefinitions = (
     accessorKey: "id",
     header: ({ column }) => <SortableHeader title={"ID"} column={column} />,
     cell: ({ row }) => (
-      <Badge
-        variant="default"
-        className="rounded-[4px] bg-primary text-white font-semibold"
+      <div
+        // variant="default"
+        className=""
       >
-        <span className="text-body-3 uppercase">ID: {row.original.id}</span>
-      </Badge>
+        <span className="text-body-3 uppercase">{row.original.id}</span>
+      </div>
     ),
   },
   {
@@ -68,7 +68,6 @@ const columnDefinitions = (
     accessorFn: (row) => row.result?.count ?? 0,
     cell: ({ row }) => (
       <span className="flex items-center gap-x-1">
-        <MapIcon className="icon shrink-0" />
         {formatNumber(row.original.result?.count ?? 0)}
       </span>
     ),


### PR DESCRIPTION
This PR introduces a public-facing Public AI Predictions page and completes the publish/retract workflow for offline predictions.

On the public side, it adds a new ‎/published-predictions route, exposes it under the “Explore Datasets → AI Predictions” navbar menu, and wires it through ‎NuqsAdapter so search, ordering, layout, pagination and map state are all synced via query params. The page supports grid, list and data-table layouts, plus a map view that renders clustered centroids with MapLibre; clicking a map point selects the corresponding prediction.

Video for implementation

https://github.com/user-attachments/assets/c9f7354a-465a-400e-8b8c-1744c612930b



